### PR TITLE
some optimizations and publishing to ghcr.io

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,25 @@
+name: Publish Docker Image
+on:
+  push:
+    tags: [ 'v*' ]
+
+jobs:
+  publish-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set version number
+        run: echo "VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          build-args: VERSION=${{ env.VERSION }}
+          tags: |
+            ghcr.io/jarvusinnovations/tippecanoe-alpine:latest
+            ghcr.io/jarvusinnovations/tippecanoe-alpine:${{ env.VERSION }}
+          cache-from: type=registry,ref=ghcr.io/jarvusinnovations/tippecanoe-alpine:latest
+          cache-to: type=inline

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set version number
-        run: echo "VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           context: .
           push: true
-          build-args: VERSION=${{ env.VERSION }}
+          build-args: version=${{ env.VERSION }}
           tags: |
             ghcr.io/jarvusinnovations/tippecanoe-alpine:latest
             ghcr.io/jarvusinnovations/tippecanoe-alpine:${{ env.VERSION }}

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -10,7 +10,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set version number
-        run: echo "VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+        run: |
+          echo "VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+          echo "DOCKER_REPOSITORY=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -26,7 +28,7 @@ jobs:
           push: true
           build-args: version=${{ env.VERSION }}
           tags: |
-            ghcr.io/jarvusinnovations/tippecanoe-alpine:latest
-            ghcr.io/jarvusinnovations/tippecanoe-alpine:${{ env.VERSION }}
-          cache-from: type=registry,ref=ghcr.io/jarvusinnovations/tippecanoe-alpine:latest
+            ghcr.io/${{ env.DOCKER_REPOSITORY }}:latest
+            ghcr.io/${{ env.DOCKER_REPOSITORY }}:${{ env.VERSION }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.DOCKER_REPOSITORY }}:latest
           cache-to: type=inline

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -12,6 +12,13 @@ jobs:
       - name: Set version number
         run: echo "VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine
 LABEL maintainer="Javier Blanco <javier_blanco@natural-solutions.eu>"
+ARG version="1.36.0"
 
 RUN apk add --no-cache sudo git g++ make libgcc libstdc++ sqlite-libs sqlite-dev zlib-dev bash curl \
   && addgroup -S tippecanoe && adduser -S -G tippecanoe tippecanoe \
   && cd /root \
-  && git clone --depth=1 https://github.com/mapbox/tippecanoe.git tippecanoe \
+  && git clone --depth=1 --branch=${version} https://github.com/mapbox/tippecanoe.git tippecanoe \
   && cd tippecanoe \
   && make \
   && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Javier Blanco <javier_blanco@natural-solutions.eu>"
 RUN apk add --no-cache sudo git g++ make libgcc libstdc++ sqlite-libs sqlite-dev zlib-dev bash curl \
   && addgroup -S tippecanoe && adduser -S -G tippecanoe tippecanoe \
   && cd /root \
-  && git clone https://github.com/mapbox/tippecanoe.git tippecanoe \
+  && git clone --depth=1 https://github.com/mapbox/tippecanoe.git tippecanoe \
   && cd tippecanoe \
   && make \
   && make install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,23 @@ FROM alpine
 LABEL maintainer="Javier Blanco <javier_blanco@natural-solutions.eu>"
 ARG version="1.36.0"
 
-RUN apk add --no-cache sudo git g++ make libgcc libstdc++ sqlite-libs sqlite-dev zlib-dev bash curl \
-  && addgroup -S tippecanoe && adduser -S -G tippecanoe tippecanoe \
+# set up user
+RUN addgroup -S tippecanoe && adduser -S -G tippecanoe tippecanoe
+WORKDIR /home/tippecanoe
+
+# install runtime dependencies
+RUN apk add --no-cache libgcc libstdc++ sqlite-libs bash
+
+# build tippecanoe
+RUN apk add --no-cache git g++ make sqlite-dev zlib-dev \
   && cd /root \
   && git clone --depth=1 --branch=${version} https://github.com/mapbox/tippecanoe.git tippecanoe \
   && cd tippecanoe \
   && make \
   && make install \
   && rm -rf /root/tippecanoe \
-  && apk del git g++ make sqlite-dev
+  && apk del git g++ make sqlite-dev zlib-dev
 
+# configure entrypoint
 USER tippecanoe
-WORKDIR /home/tippecanoe
 ENTRYPOINT /bin/bash


### PR DESCRIPTION
Could be extended to publish to dockerhub easily:

- Optimize the layering a bit
- Build specific tagged versions via build arg
- Automate building specified version via creating a tag/release
- Publish container images to public ghcr.io registry
   - I'm publishing to our fork right now: https://github.com/orgs/JarvusInnovations/packages/container/package/tippecanoe-alpine
   - If this can be merged, I'd rather switch to using yours as the original authors